### PR TITLE
[DEVTASK-462][DEVTASK-452][DEVTASK-461] Fix Feature video call from rc3

### DIFF
--- a/canscloud-android-sdk/build.gradle
+++ b/canscloud-android-sdk/build.gradle
@@ -191,7 +191,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.cans-communication'
             artifactId = 'canscloud-android-sdk'
-            version = '3.0.2'
+            version = '3.0.3'
 
             afterEvaluate {
                 from components.release

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -441,6 +441,7 @@ class CansCenter : Cans {
                 }
 
                 Call.State.Error -> {
+                    lastRemoteCameraOnState = null
                     updateMissedCallLogs()
                     if (audioManager?.isBluetoothScoOn == true) {
                         audioManager?.stopBluetoothSco()
@@ -453,7 +454,7 @@ class CansCenter : Cans {
                 }
 
                 Call.State.End -> {
-                    lastRemoteCameraOnState = null // Reset so next call starts fresh
+                    lastRemoteCameraOnState = null
                     updateMissedCallLogs()
                     if (audioManager?.isBluetoothScoOn == true) {
                         audioManager?.stopBluetoothSco()
@@ -461,6 +462,10 @@ class CansCenter : Cans {
                         audioManager?.mode = AudioManager.MODE_NORMAL
                     }
                     mVibrator.cancel()
+                }
+
+                Call.State.Released -> {
+                    lastRemoteCameraOnState = null
                 }
 
                 else -> {
@@ -2363,13 +2368,13 @@ class CansCenter : Cans {
         }
     }
 
-    // ----- START : add for Video Call
     override fun makeVideoCall(number: String) {
         val address = core.interpretUrl(number) ?: return
         val params = core.createCallParams(null)
         params?.isVideoEnabled = true
         params?.isAudioMulticastEnabled = false
         params?.videoDirection = org.linphone.core.MediaDirection.SendRecv
+        core.isVideoPreviewEnabled = true
 
         if (params != null) {
             core.inviteAddressWithParams(address, params)
@@ -2438,5 +2443,4 @@ class CansCenter : Cans {
         core.preferredVideoDefinition = Factory.instance().createVideoDefinition(1280, 720)
         core.isAudioMulticastEnabled = true
     }
-    // ----- END
 }

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -375,9 +375,13 @@ class CansCenter : Cans {
             when (state) {
                 Call.State.IncomingEarlyMedia, Call.State.IncomingReceived -> {
                     Log.w(TAG, "Call.State.IncomingEarlyMedia, Call.State.IncomingReceived")
-                    val loginType = corePreferences.loginInfo.logInType
-                    if (!loginType.isNullOrEmpty()) {
-                        vibrator()
+                    // Only vibrate on IncomingReceived; IncomingEarlyMedia fires first for the
+                    // same call and would trigger a second vibration that MIUI throttles.
+                    if (state == Call.State.IncomingReceived) {
+                        val loginType = corePreferences.loginInfo.logInType
+                        if (!loginType.isNullOrEmpty()) {
+                            vibrator()
+                        }
                     }
                 }
 

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -283,6 +283,8 @@ class CansCenter : Cans {
 
     private var currentAudioRoute: AudioRoute = AudioRoute.EARPIECE_OR_HEADSET
 
+    private var lastRemoteCameraOnState: Boolean? = null
+
     private val accountListener: AccountListenerStub = object : AccountListenerStub() {
         override fun onRegistrationStateChanged(
             account: Account,
@@ -382,12 +384,25 @@ class CansCenter : Cans {
                 Call.State.StreamsRunning, Call.State.Updating, Call.State.UpdatedByRemote -> {
                     mVibrator.cancel()
 
-                    val remoteParams = call.remoteParams
-                    val isRemoteCameraOn = remoteParams?.isVideoEnabled == true &&
-                            (remoteParams.videoDirection == org.linphone.core.MediaDirection.SendRecv ||
-                                    remoteParams.videoDirection == org.linphone.core.MediaDirection.SendOnly)
+                    // Skip during Updating: remoteParams reflects mid-negotiation SDP which may
+                    // temporarily read a stale direction, causing a spurious isRemoteCameraOn=false
+                    // event that would hide the remote view and trigger a setRemoteVideoWindow
+                    // re-bind, clearing Linphone's render buffer (black flash).
+                    if (state != Call.State.Updating) {
+                        val remoteParams = call.remoteParams
+                        val isRemoteCameraOn = remoteParams?.isVideoEnabled == true &&
+                                (remoteParams.videoDirection == org.linphone.core.MediaDirection.SendRecv ||
+                                        remoteParams.videoDirection == org.linphone.core.MediaDirection.SendOnly)
 
-                    listeners.forEach { it.onRemoteVideoStateChanged(isRemoteCameraOn) }
+                        // Only fire when value changed — prevents React from toggling display:none
+                        // on the remote TextureView (and losing nativeVideoWindowId) during our own
+                        // direction-only re-INVITEs where the remote camera state is unchanged.
+                        if (isRemoteCameraOn != lastRemoteCameraOnState) {
+                            Log.d(TAG, "onRemoteVideoStateChanged: $isRemoteCameraOn (was $lastRemoteCameraOnState, state=$state)")
+                            lastRemoteCameraOnState = isRemoteCameraOn
+                            listeners.forEach { it.onRemoteVideoStateChanged(isRemoteCameraOn) }
+                        }
+                    }
 
                     if (AudioRouteUtils.isBluetoothAudioRouteAvailable()) {
                         Log.i(TAG, "[Auto-Route] StreamsRunning: Enforcing Bluetooth")
@@ -438,6 +453,7 @@ class CansCenter : Cans {
                 }
 
                 Call.State.End -> {
+                    lastRemoteCameraOnState = null // Reset so next call starts fresh
                     updateMissedCallLogs()
                     if (audioManager?.isBluetoothScoOn == true) {
                         audioManager?.stopBluetoothSco()

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -2197,29 +2197,10 @@ class CansCenter : Cans {
 
         var room = core.getChatRoom(remoteAddress, localAddress)
 
-        val loginType = cansCenter().corePreferences.loginInfo.logInType
-//        val expectedBackend = if (loginType == LogInType.ACCOUNT.value && defaultAccount?.params?.conferenceFactoryUri != null)
-//            ChatRoom.Backend.FlexisipChat
-//        else
-//            ChatRoom.Backend.Basic
-//
-//        val currentBackend = room?.params?.chatParams?.backend ?: ChatRoom.Backend.Basic
-
-//        if (room != null && currentBackend != expectedBackend) {
-//            Log.w(
-//                TAG,
-//                "Chat room backend mismatch (current: $currentBackend, expected: $expectedBackend). " +
-//                        "Preserving existing room to avoid destructive delete/recreate."
-//            )
-//        }
-
         if (room == null) {
             val params = core.createDefaultChatRoomParams()
             params.backend = ChatRoom.Backend.Basic
             params.isGroupEnabled = false
-//            if (expectedBackend == ChatRoom.Backend.FlexisipChat) {
-//                params.subject = "Chat"
-//            }
             room = core.createChatRoom(params, localAddress, arrayOf(remoteAddress))
         }
 
@@ -2391,7 +2372,6 @@ class CansCenter : Cans {
         params?.videoDirection = org.linphone.core.MediaDirection.SendRecv
 
         if (params != null) {
-//            core.isVideoPreviewEnabled = true
             core.inviteAddressWithParams(address, params)
         }
     }

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -2182,28 +2182,28 @@ class CansCenter : Cans {
         var room = core.getChatRoom(remoteAddress, localAddress)
 
         val loginType = cansCenter().corePreferences.loginInfo.logInType
-        val expectedBackend = if (loginType == LogInType.ACCOUNT.value && defaultAccount?.params?.conferenceFactoryUri != null)
-            ChatRoom.Backend.FlexisipChat
-        else
-            ChatRoom.Backend.Basic
+//        val expectedBackend = if (loginType == LogInType.ACCOUNT.value && defaultAccount?.params?.conferenceFactoryUri != null)
+//            ChatRoom.Backend.FlexisipChat
+//        else
+//            ChatRoom.Backend.Basic
+//
+//        val currentBackend = room?.params?.chatParams?.backend ?: ChatRoom.Backend.Basic
 
-        val currentBackend = room?.params?.chatParams?.backend ?: ChatRoom.Backend.Basic
-
-        if (room != null && currentBackend != expectedBackend) {
-            Log.w(
-                TAG,
-                "Chat room backend mismatch (current: $currentBackend, expected: $expectedBackend). " +
-                        "Preserving existing room to avoid destructive delete/recreate."
-            )
-        }
+//        if (room != null && currentBackend != expectedBackend) {
+//            Log.w(
+//                TAG,
+//                "Chat room backend mismatch (current: $currentBackend, expected: $expectedBackend). " +
+//                        "Preserving existing room to avoid destructive delete/recreate."
+//            )
+//        }
 
         if (room == null) {
             val params = core.createDefaultChatRoomParams()
-            params.backend = expectedBackend
+            params.backend = ChatRoom.Backend.Basic
             params.isGroupEnabled = false
-            if (expectedBackend == ChatRoom.Backend.FlexisipChat) {
-                params.subject = "Chat"
-            }
+//            if (expectedBackend == ChatRoom.Backend.FlexisipChat) {
+//                params.subject = "Chat"
+//            }
             room = core.createChatRoom(params, localAddress, arrayOf(remoteAddress))
         }
 
@@ -2375,7 +2375,7 @@ class CansCenter : Cans {
         params?.videoDirection = org.linphone.core.MediaDirection.SendRecv
 
         if (params != null) {
-            core.isVideoPreviewEnabled = true
+//            core.isVideoPreviewEnabled = true
             core.inviteAddressWithParams(address, params)
         }
     }


### PR DESCRIPTION
task:
https://www.notion.so/cns-can/CansCall-Android-Implementation-outgoing-and-incoming-video-call-348e0843af3880e796b1e899f754fb03

https://www.notion.so/cns-can/CansCall-Android-Implement-manage-active-video-call-and-controls-1-34fe0843af3880a788b1d44632b119b1

fix bug :

Video call เลื่อน self preview ไปมุมอื่นของหน้าจอไม่ได้
Video call หลังกด End call จะกลับมาหน้า History
Outgoing video call ไม่แสดง self preview ถ้าคู่สายยังไม่มี call action
กรณีย่อแอพแล้วมี video call เข้า แอพไม่แสดงหน้า video call
โทรออกปกติ แต่ระบบขึ้นเป็นโทร Video call
ใช้งานแชท cans account 712->707 ไม่ได้
ยังเหลือ

bug : Video call ใช้งานปุ่มเปิด/ปิดกล้อง หน้าจอคู่สายจะกระพริบ
เพิ่มปุ่มโทรในหน้า Contacts