### PR TITLE
DONE : Fix Foreground Service

### DIFF
--- a/canscloud-android-sdk/build.gradle
+++ b/canscloud-android-sdk/build.gradle
@@ -191,7 +191,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.cans-communication'
             artifactId = 'canscloud-android-sdk'
-            version = '3.0.5'
+            version = '3.0.6'
 
             afterEvaluate {
                 from components.release

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/NotificationsManager.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/NotificationsManager.kt
@@ -67,6 +67,7 @@ class NotificationsManager(private val context: Context) {
             )
             val intent = Intent()
             intent.setClass(cansCenter().context, CoreService::class.java)
+            intent.putExtra("StartForeground", true)
             try {
                 cansCenter().context.startForegroundService(intent)
             } catch (ise: IllegalStateException) {


### PR DESCRIPTION
Issue: ForegroundServiceDidNotStartInTimeException in CansCloud SDK :
แอปเกิด Crash ด้วย ForegroundServiceDidNotStartInTimeException เมื่อมีการเรียกใช้งาน Service จาก CansCloud SDK บน Android

Root Cause :
กฎของ Android เมื่อแอปเรียก startForegroundService() ระบบจะให้เวลาเพียง 5 วินาที ในการเรียกฟังก์ชัน startForeground() เพื่อแสดง Notification ให้ผู้ใช้ทราบ หากเรียกไม่ทันตามกำหนด ระบบจะสั่งหยุด Service ทันทีและโยน Exception ดังกล่าวออกมา

ในโค้ดเดิม NotificationsManager ทำการเริ่ม Service โดยไม่มีการส่งสัญญาณบอกให้ CoreService ว่าจำเป็นต้องแสดง Foreground Notification ทันที ทำให้ CoreService ไม่ยอมเรียก startForeground() และทำงานไม่ทันตามกรอบเวลาที่ระบบกำหนด

Why it appeared now?
ปัญหาเพิ่งปรากฏขึ้นหลังจากย้ายมาใช้ Expo Development Client ในการรันแอป ซึ่งเป็นการ build ตัวโปรเจกต์ในรูปแบบ Native App เต็มตัวททำให้ Android OS บังคับใช้กฎความปลอดภัย (Background Execution Limits) อย่างเคร่งครัดตามมาตรฐานของ Android เวอร์ชันปัจจุบัน

Fix :
แก้ไขโดยการส่ง Extra เพิ่มเข้าไปใน Intent เพื่อบังคับสถานะการทำงาน:

Implementation: เพิ่ม intent.putExtra("StartForeground", true) ก่อนการเรียก startForegroundService()

Result: เมื่อ CoreService.onStartCommand() ได้รับ Flag นี้ จะทำการเรียก startForeground() ทันที ส่งผลให้ Service เข้าสู่สถานะ Foreground ได้ภายในกรอบเวลา 5 วินาทีตามข้อกำหนดของ Android OS