### PR TITLE
DONE : Fix Foreground Service & Behavior changes: Apps targeting Andr…

### DIFF
--- a/canscloud-android-sdk/build.gradle
+++ b/canscloud-android-sdk/build.gradle
@@ -191,7 +191,7 @@ publishing {
         release(MavenPublication) {
             groupId = 'com.github.cans-communication'
             artifactId = 'canscloud-android-sdk'
-            version = '3.0.6'
+            version = '3.0.7'
 
             afterEvaluate {
                 from components.release

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -1867,6 +1867,9 @@ class CansCenter : Cans {
         indexAccount: Int,
         listener: CansRegisterAccountListenerStub
     ) {
+        if (::accountDefault.isInitialized) {
+            accountDefault.removeListener(accountListener)
+        }
         val account = core.accountList[indexAccount]
         accountDefault = account
         accountDefault.addListener(accountListener)
@@ -1876,7 +1879,9 @@ class CansCenter : Cans {
     override fun removeCansRegisterAccountListener(
         listener: CansRegisterAccountListenerStub
     ) {
-        accountDefault.removeListener(accountListener)
+        if (::accountDefault.isInitialized) {
+            accountDefault.removeListener(accountListener)
+        }
         registerAccountListeners.remove(listener)
     }
 

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/CansCenter.kt
@@ -1867,10 +1867,14 @@ class CansCenter : Cans {
         indexAccount: Int,
         listener: CansRegisterAccountListenerStub
     ) {
+        val accounts = core.accountList
+        if (indexAccount < 0 || indexAccount >= accounts.size) {
+            return
+        }
+        val account = accounts[indexAccount]
         if (::accountDefault.isInitialized) {
             accountDefault.removeListener(accountListener)
         }
-        val account = core.accountList[indexAccount]
         accountDefault = account
         accountDefault.addListener(accountListener)
         registerAccountListeners.add(listener)

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/CoreService.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/CoreService.kt
@@ -19,19 +19,55 @@
  */
 package cc.cans.canscloud.sdk.core
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Intent
+import android.content.pm.ServiceInfo
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import cc.cans.canscloud.sdk.R
 import cc.cans.canscloud.sdk.core.CoreContextSDK.Companion.cansCenter
 import org.linphone.core.tools.Log
 import org.linphone.core.tools.service.CoreService
 
 class CoreService : CoreService() {
     override fun onCreate() {
+        // startForeground() must be called before super.onCreate() to satisfy the Android 8+
+        // 5-second rule. super.onCreate() blocks on linphone JNI initialization which can
+        // easily exceed that window, causing ForegroundServiceDidNotStartInTimeException.
+        startEarlyForeground()
         super.onCreate()
         cansCenter().coreContext.notificationsManager.service = this
         Log.i("[Service] Created")
     }
 
+    private fun startEarlyForeground() {
+        val channelId = "sdk_core_startup"
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val nm = getSystemService(NotificationManager::class.java)
+            nm?.createNotificationChannel(
+                NotificationChannel(channelId, "Call Service", NotificationManager.IMPORTANCE_LOW)
+            )
+        }
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.drawable.topbar_call_notification)
+            .setOngoing(true)
+            .build()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL)
+        } else {
+            startForeground(1, notification)
+        }
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Defensively satisfy Android's 5-second startForeground() rule immediately.
+        // This prevents ForegroundServiceDidNotStartInTimeException if the service is already
+        // running (skipping onCreate) and subsequent startForeground() calls silently fail
+        // (e.g. missing DATA_SYNC type on Android 15+).
+        // startEarlyForeground() safely uses PHONE_CALL type which is guaranteed to be declared.
+        startEarlyForeground()
+
         if (cansCenter().corePreferences.keepServiceAlive) {
             Log.i("[Service] Starting as foreground to keep app alive in background")
             cansCenter().coreContext.notificationsManager.startForegroundToKeepAppAlive(this, false)

--- a/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/CoreService.kt
+++ b/canscloud-android-sdk/src/main/java/cc/cans/canscloud/sdk/core/CoreService.kt
@@ -42,21 +42,32 @@ class CoreService : CoreService() {
     }
 
     private fun startEarlyForeground() {
-        val channelId = "sdk_core_startup"
+        val channelId = getString(R.string.notification_channel_service_id)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val nm = getSystemService(NotificationManager::class.java)
+            val channelName = getString(R.string.notification_channel_service_name)
             nm?.createNotificationChannel(
-                NotificationChannel(channelId, "Call Service", NotificationManager.IMPORTANCE_LOW)
+                NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_LOW).apply {
+                    enableVibration(false)
+                    enableLights(false)
+                    setShowBadge(false)
+                },
             )
         }
         val notification = NotificationCompat.Builder(this, channelId)
+            .setContentTitle(getString(R.string.notification_channel_service_name))
+            .setContentText(getString(R.string.service_description))
             .setSmallIcon(R.drawable.topbar_call_notification)
             .setOngoing(true)
             .build()
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            startForeground(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL)
-        } else {
-            startForeground(1, notification)
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(1, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL)
+            } else {
+                startForeground(1, notification)
+            }
+        } catch (e: Exception) {
+            Log.e("[Service] Failed to start early foreground: $e")
         }
     }
 


### PR DESCRIPTION
Fix  
1. แอพเด้งหลุดจากการทำ ForegroundService 
2.ป้องกัน android.app.ActivityThread.generateForegroundServiceDidNotStopInTimeException เหมือนแอพ CANSCloud 

Issue :
https://play.google.com/console/developers/7577963315498852812/app/4972125287314923336/vitals/crashes/bd25b8e7e0ecc4cbe7fb6f9c944a39ce/details?isUserPerceived=true&device=samsung%2Fa17x

Doc : 
https://developer.android.com/about/versions/15/behavior-changes-15

key "Note: The 6-hour time limit is shared by all of an app's dataSync foreground services. For example, if an app runs a dataSync service for four hours, then starts a different dataSync service, that second service will only be allowed to run for two hours. However, if the user brings the app to the foreground, the timer resets and the app has 6 hours available."

https://developer.android.com/about/versions/15/behavior-changes-15#datasync-timeout

<img width="652" height="393" alt="image" src="https://github.com/user-attachments/assets/9ffeed66-1063-49c0-8f96-aa8c9c476ed5" />
